### PR TITLE
Rename project to `vscode-packaging`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# vscode-aur-packaging
+# vscode-packaging
 
-This is the source code repository for the `aur-packaging` VS Code extension.
+This is the source code repository for the `packaging` VS Code extension.
 
 This document is for **contributors,** not for users of this extension.  
 For **user documentation,** see: [extension/README.md](./extension/README.md)  
@@ -87,16 +87,16 @@ To also upgrade Yarn itself, run `yarn upgrade-all`.
 ### The thing about vulnerabilities in transitive dependencies
 
 People sometimes discover vulnerabilities in packages on which
-vscode-aur-packaging depends.
+vscode-packaging depends.
 
 If that happens and a patch comes out, I need to upgrade the
 affected package to a newer version, which includes the patch.
 
 But a vulnerability might also affect a package on which
-vscode-aur-packaging depends only indirectly, e.g. through a
+vscode-packaging depends only indirectly, e.g. through a
 transitive requirement. A patch may exist for such a package, but
 somewhere in the chain of dependencies (from the vulnerable package
-all the way down to vscode-aur-packaging), the patch may be
+all the way down to vscode-packaging), the patch may be
 outside the specified semver range so I **can’t upgrade** the
 package via the usual `yarn up` or `yarn up -R` command.
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,17 +1,28 @@
-# AUR packaging
+# Packaging
 
-This extension adds support for user-contributed
-[PKGBUILD](https://wiki.archlinux.org/title/PKGBUILD) files in the
+This extension helps you work with package definition files for
+package repositories.
+
+It currently supports only a single type of package repository: the
 [Arch User Repository](https://aur.archlinux.org/) (AUR).
 
-## What it does
+## Features
 
-This extension configures the
+### PKGBUILD (AUR)
+
+The Packaging extension supports user-contributed
+[PKGBUILD](https://wiki.archlinux.org/title/PKGBUILD) files in the
+AUR.
+
+For `PKGBUILD` files opened in VS Code, this extension enables
+linting through the
 [ShellCheck](https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck)
-extension so it applies a specific set of rules to `PKGBUILD` files.
+extension.
 
-For `PKGBUILD` files opened in VS Code, this extension configures
-ShellCheck in the following ways:
+By default, however, ShellCheck emits a number of unhelpful warnings
+that are false alarms in the context of `PKGBUILD` files. To remove
+those false alarms, this extension configures the ShellCheck
+extension in the following ways:
 
 - Sets Bash as the shell.
 
@@ -35,9 +46,9 @@ Specifically, it won’t work with the ShellCheck extension version
 
 If you want to use this extension, you can either
 [package it
-yourself](https://github.com/claui/vscode-aur-packaging/blob/main/README.md#building-the-extension)
+yourself](https://github.com/claui/vscode-packaging/blob/main/README.md#building-the-extension)
 or wait for
-[the first release](https://github.com/claui/vscode-aur-packaging/milestone/1)
+[the first release](https://github.com/claui/vscode-packaging/milestone/1)
 to be published on the VS Code Marketplace.
 
 ## FAQ

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "aur-packaging",
+  "name": "packaging",
   "version": "0.2.0",
   "publisher": "claui",
   "engines": {
     "vscode": "^1.69.0"
   },
   "license": "SEE LICENSE IN README.md",
-  "displayName": "AUR packaging",
+  "displayName": "Packaging",
   "description": "Support for user-contributed PKGBUILDs in the Arch User Repository (AUR)",
   "categories": [],
   "keywords": [],
@@ -15,14 +15,14 @@
   "contributes": {
     "commands": [
       {
-        "command": "aur-packaging.action.showLog",
-        "title": "AUR packaging: Show extension log"
+        "command": "packaging.action.showLog",
+        "title": "Packaging: Show extension log"
       }
     ],
     "configuration": {
-      "title": "AUR packaging",
+      "title": "Packaging",
       "properties": {
-        "aur-packaging.executablePath": {
+        "packaging.executablePath": {
           "type": "string",
           "markdownDescription": "Path to the `foo` executable, e. g. `/usr/local/bin/foo`.  \nLeave blank if it’s already on your `PATH`.",
           "scope": "machine-overridable"
@@ -72,5 +72,5 @@
   "extensionKind": [
     "workspace"
   ],
-  "repository": "github:claui/vscode-aur-packaging"
+  "repository": "github:claui/vscode-packaging"
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -4,7 +4,7 @@ import { statusItem } from "./language";
 import { outputChannel } from "./logger";
 import { SubscriptionHelper } from "./shellcheck";
 
-const ACTION_SHOW_LOG: string = "aur-packaging.action.showLog";
+const ACTION_SHOW_LOG: string = "packaging.action.showLog";
 
 export function activate(context: ExtensionContext) {
   commands.registerCommand(ACTION_SHOW_LOG, () => {

--- a/extension/src/logger.ts
+++ b/extension/src/logger.ts
@@ -9,7 +9,7 @@ export interface Logger {
 }
 
 export const outputChannel: OutputChannel =
-  window.createOutputChannel("AUR packaging");
+  window.createOutputChannel("Packaging");
 
 export const log: Logger = {
   debug: function (...args) {

--- a/extension/syntaxes/aur-pkgbuild.tmLanguage.json
+++ b/extension/syntaxes/aur-pkgbuild.tmLanguage.json
@@ -2,7 +2,7 @@
   "name": "aur-pkgbuild",
   "scopeName": "source.shell.pkgbuild.aur",
   "uuid": "b758f368-67dc-4719-b095-756c7051c313",
-  "comment": "AUR PKGBUILD",
+  "comment": "PKGBUILD (AUR)",
   "patterns": [
     {
       "include": "source.shell"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-aur-packaging",
+  "name": "vscode-packaging",
   "license": "SEE LICENSE IN README.md",
   "devDependencies": {
     "@types/node": "^18.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,9 +2950,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-aur-packaging@workspace:.":
+"vscode-packaging@workspace:.":
   version: 0.0.0-use.local
-  resolution: "vscode-aur-packaging@workspace:."
+  resolution: "vscode-packaging@workspace:."
   dependencies:
     "@types/node": ^18.6.4
     "@types/vscode": ^1.69.1


### PR DESCRIPTION
Package repositories often have similar workflows.

Examples:

- AUR PKGBUILDs vs. Arch Linux core/extra/community PKGBUILDs

- AUR PKGBUILDs vs. Pacstall Pacscripts, see also #7.

From that perspective, restricting this VS Code extension to just PKGBUILDs and the AUR seems overly narrow.

Rename the project to `vscode-packaging` to allow a more flexible scope.

Closes #8.
