### PR TITLE
Fix another typo, reformat paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ well with Yarn PnP in scripts.
 
 To also upgrade Yarn itself, run `yarn upgrade-all`.
 
-### Upgrading the VS Code API
+### Upgrading the VS Code API version
 
 Upgrading the version of the `@types/vscode` package should always
 be a manual step and a conscious decision. It effectively bumps the
@@ -163,15 +163,19 @@ minimum supported VS Code version that this extension supports.
 To bump the minimum supported VS Code version, follow these steps:
 
 1. In `package.json`, manually update the minimum version to a new
-   version triple (e.g. `^1.99.0`).  
-   Make sure to preserve the `^` prefix as you change the value.
+   version tuple (e.g. `=1.99`).  
+   Make sure to preserve the `=` prefix as you change the value.
 
-2. In `extension/package.json` under the `engines` section, manually
+2. In `package.json`, modify the `upgrade-package` script to update
+   the same tuple (e.g `@types/vscode@=1.99`).  
+   Preserve the `@types/vscode@=` prefix as you change the value.
+
+3. In `extension/package.json` under the `engines` section, manually
    update the value of the `vscode` property to the new version
-   triple.  
+   tuple.  
    Preserve the `^` prefix as you change the value.
 
-3. Run `yarn clean-install`.
+4. Run `yarn clean-install`.
 
 ## Handling vulnerable dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
 # vscode-packaging
 
-This is the source code repository for the `packaging` VS Code extension.
+This is the source code repository for the `packaging` VS Code
+extension.
 
-This document is for **contributors,** not for users of this extension.  
+This document is for **contributors,** not for users of this
+extension.  
 For **user documentation,** see: [extension/README.md](./extension/README.md)  
 For **license information,** see the bottom of this document.
 
 ## About the extension
 
-For a list of features and details, see the user documentation: [extension/README.md](./extension/README.md)
+For a list of features and details, see the user documentation:
+[extension/README.md](./extension/README.md)
 
 ## Requirements for contributing
 
-Working on this VS Code extension requires the following programs to be installed on your system:
+Working on this VS Code extension requires the following programs to
+be installed on your system:
 
 - `yarn` (required)
 - `nvm` (recommended)
 
 ## Preparing your session
 
-To prepare your session, `cd` to the project root directory, then run `nvm use`.
+To prepare your session, `cd` to the project root directory, then
+run `nvm use`.
 
 ## Installing dependencies
 
@@ -31,7 +36,8 @@ If that fails, consult the _Maintenance_ section.
 
 To build the extension, run: `yarn package`
 
-Unlike `vsce package`, running `yarn package` will work around issue [microsoft/vscode-vsce#517](https://github.com/microsoft/vscode-vsce/issues/517).
+Unlike `vsce package`, running `yarn package` will work around issue
+[microsoft/vscode-vsce#517](https://github.com/microsoft/vscode-vsce/issues/517).
 Use `yarn package` as long as the issue is unresolved.
 
 ## Publishing the extension
@@ -66,7 +72,10 @@ After deciding on a target version, run:
 - `yarn login`
 - `yarn publish [--pre-release] [version]`
 
-The `yarn publish` command first updates the version number in [extension/package.json](./extension/package.json) to the given version. Then it packages and publishes the extension to the VS Code Extension Marketplace.
+The `yarn publish` command first updates the version number in
+[extension/package.json](./extension/package.json) to the given
+version. Then it packages and publishes the extension to the VS Code
+Extension Marketplace.
 
 ### Committing, tagging and creating a GitHub prerelease and PR
 
@@ -93,15 +102,22 @@ pull request against `main`:
 
 ### yarn install
 
-To install the current project dependencies as specified in `package.json` and `yarn.lock`, run `yarn install`.
+To install the current project dependencies as specified in
+`package.json` and `yarn.lock`, run `yarn install`.
 
 ### yarn clean-install
 
-If the Yarn version has changed and you run `yarn install`, Yarn will try to upgrade itself. That causes changes to several files, such as the `LICENSE` files I have placed into several subdirectories.
+If the Yarn version has changed and you run `yarn install`, Yarn
+will try to upgrade itself. That causes changes to several files,
+such as the `LICENSE` files I have placed into several
+subdirectories.
 
-Anytime that happens, run the `yarn clean-install` script, a wrapper around `yarn install` which cleans up afterwards.
+Anytime that happens, run the `yarn clean-install` script, a wrapper
+around `yarn install` which cleans up afterwards.
 
-Note that the `yarn clean-install` script may fail and tell you to run `yarn install` instead. I haven’t figured out why it does that. If that happens, run `yarn install` followed by `yarn clean-install`.
+Note that the `yarn clean-install` script may fail and tell you to
+run `yarn install` instead. I haven’t figured out why it does that.
+If that happens, run `yarn install` followed by `yarn clean-install`.
 
 ### yarn outdated
 
@@ -115,7 +131,8 @@ possible, but leaves your `package.json` as is.
 
 ### yarn upgrade-packages
 
-The built-in `yarn up` command can be a bit cumbersome to use if you want to upgrade all dependencies in one go.
+The built-in `yarn up` command can be a bit cumbersome to use if you
+want to upgrade all dependencies in one go.
 
 Running the `yarn upgrade-packages` script will upgrade all relevant
 dependencies. That includes the `@types` and `@yarnpkg` scopes but
@@ -126,9 +143,12 @@ section _Upgrading the VS Code API_.
 
 ### yarn upgrade-yarn-itself
 
-To upgrade Yarn PnP to the latest available version, run the `yarn upgrade-yarn-itself` script.
+To upgrade Yarn PnP to the latest available version, run the
+`yarn upgrade-yarn-itself` script.
 
-Note that the script will only print manual instructions. That’s because Yarn makes changes to `package.json`, and that doesn’t play well with Yarn PnP in scripts.
+Note that the script will only print manual instructions. That’s
+because Yarn makes changes to `package.json`, and that doesn’t play
+well with Yarn PnP in scripts.
 
 ### yarn upgrade-all
 
@@ -221,9 +241,12 @@ that depends on ………… v………… or higher.)
 
 ## License
 
-This source code repository contains code and assets sourced from different parties. Therefore, multiple sets of license terms apply to different parts of this source code repository.
+This source code repository contains code and assets sourced from
+different parties. Therefore, multiple sets of license terms apply
+to different parts of this source code repository.
 
-The following table shows which terms apply to which parts of this source code repository:
+The following table shows which terms apply to which parts of this
+source code repository:
 
 | Directory tree | Description | License | Terms |
 |---|---|---|---|
@@ -232,8 +255,11 @@ The following table shows which terms apply to which parts of this source code r
 | `./.yarn/sdks` | SDK files for `yarn` | BSD-2-Clause | [License](./.yarn/sdks/LICENSE) |
 | `./extension` | The source code for this VS Code extension | Apache-2.0 | [License](./extension/LICENSE.txt)<br>with [License header](./extension/README.md#license) |
 
-In each of the directories the table mentions, you will find one license file, named `LICENSE` or `LICENSE.txt`.  
-Each license file applies to the directory that contains it, including all subdirectories, but excluding any subdirectory tree whose root has a license file on its own.
+In each of the directories the table mentions, you will find one
+license file, named `LICENSE` or `LICENSE.txt`.  
+Each license file applies to the directory that contains it,
+including all subdirectories, but excluding any subdirectory tree
+whose root has a license file on its own.
 
 ## License header
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ minimum supported VS Code version that this extension supports.
 To bump the minimum supported VS Code version, follow these steps:
 
 1. In `package.json`, manually update the minimum version to a new
-   version triple (e.g. `~=1.99.0`).  
-   Make sure to preserve the `~=` prefix as you change the value.
+   version triple (e.g. `^1.99.0`).  
+   Make sure to preserve the `^` prefix as you change the value.
 
 2. In `extension/package.json` under the `engines` section, manually
    update the value of the `vscode` property to the new version

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "SEE LICENSE IN README.md",
   "devDependencies": {
     "@types/node": "^18.7.13",
-    "@types/vscode": "~=1.69.0",
+    "@types/vscode": "=1.69",
     "@yarnpkg/sdks": "^2.6.3",
     "eslint": "^8.23.0",
     "typescript": "^4.8.2",
@@ -19,7 +19,7 @@
     "publish": "cd extension && vsce publish --no-dependencies --yarn --githubBranch main/extension",
     "upgrade-all": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn upgrade-packages' && false",
     "upgrade-lockfile": "yarn up -R '**' && yarn clean-install",
-    "upgrade-packages": "yarn up '*' '@types/node' '@yarnpkg/*' && yarn up -R '**' && yarn clean-install",
+    "upgrade-packages": "yarn up '**' '@types/vscode@=1.69' && yarn up -R '**' && yarn clean-install",
     "upgrade-yarn-itself": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn clean-install' && false",
     "vscode:prepublish": "yarn compile"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "upgrade-all": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn upgrade-packages' && false",
     "upgrade-lockfile": "yarn up -R '**' && yarn clean-install",
     "upgrade-packages": "yarn up '*' '@types/node' '@yarnpkg/*' && yarn up -R '**' && yarn clean-install",
-    "upgrade-yarn-itself": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && clean-install' && false",
+    "upgrade-yarn-itself": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn clean-install' && false",
     "vscode:prepublish": "yarn compile"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,7 +233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/vscode@npm:~=1.69.0":
+"@types/vscode@npm:=1.69":
   version: 1.69.1
   resolution: "@types/vscode@npm:1.69.1"
   checksum: 5e34bf677106f8e92722537a87d25f9e96b1bed5ecc381f1af1c89382be0fa7690e38e2d707be57d0aca5b37c98feec54dae19b29784a2050fdc92588fbb745e
@@ -3211,7 +3211,7 @@ __metadata:
   resolution: "vscode-packaging@workspace:."
   dependencies:
     "@types/node": ^18.7.13
-    "@types/vscode": ~=1.69.0
+    "@types/vscode": =1.69
     "@yarnpkg/sdks": ^2.6.3
     eslint: ^8.23.0
     typescript: ^4.8.2


### PR DESCRIPTION
- Fix typo
- Format paragraphs
- Ensure `yarn upgrade-packages` leaves vscode alone
